### PR TITLE
Add arc2places consumer

### DIFF
--- a/example.config.json
+++ b/example.config.json
@@ -42,6 +42,10 @@
   "oauth": {
     "consumerKey": "CONSUMER KEY",
     "consumerSecret": "CONSUMER SECRET",
+    "arc2places": {
+      "consumerKey": "CONSUMER KEY",
+      "consumerSecret": "CONSUMER SECRET"
+    },
     "external": false,
     "local": {
       "auth": "/account/logon/",

--- a/src/oauth/authorizationRequest.js
+++ b/src/oauth/authorizationRequest.js
@@ -11,7 +11,8 @@ module.exports = function(config) {
             requestedUrl = req.protocol + '://' + req.get('Host') + req.originalUrl,
             compareSig = tools.osmOauth._getSignature(req.method, requestedUrl, tools.verification.baseString(auths), tokens.access_token_secret),
             josmCompareSig = tools.josmOauth._getSignature(req.method, requestedUrl, tools.verification.baseString(auths), tokens.access_token_secret);
-          if (encodeURIComponent(compareSig) === origSig || encodeURIComponent(josmCompareSig) === origSig) {
+            arcCompareSig = tools.arcOauth._getSignature(req.method, requestedUrl, tools.verification.baseString(auths), tokens.access_token_secret);
+          if (encodeURIComponent(compareSig) === origSig || encodeURIComponent(josmCompareSig) === origSig || encodeURIComponent(arcCompareSig) === origSig) {
             callback({
               'valid': !e,
               'userId': userId,

--- a/src/oauth/tools.js
+++ b/src/oauth/tools.js
@@ -57,6 +57,15 @@ module.exports = function(config) {
         null,
         'HMAC-SHA1'
       ),
+      arcOauth: new oauth.OAuth(
+          'http://localhost/oauth/request_token', //not used
+          'http://localhost/oauth/access_token', //not used
+          oauthSettings.arc2places.consumerKey,
+          oauthSettings.arc2places.consumerSecret,
+          '1.0',
+          null,
+          'HMAC-SHA1'
+      ),
       addRequestToken: function(token, tokenSecret, callback) {
         var query = 'SELECT new_session(\'{{token}}\', \'{{tokenSecret}}\')';
         query = database().addParams(query, 'addToken', {


### PR DESCRIPTION
I think this should work to enable another consumer in the places api.  we just need to create a consumer key/secret, and a session to test it.  I’ll try testing tomorrow on my server.

In normal operation, I think the client needs to call /oauth/request_token, then send the request_token to Nate's server, so it can send the user id to /oauth/add_active_directory_user to trigger creation of the access token/secret, then the client can retrieve the token/secret with /oauth/access_token

...but I may be completely upside down.