### PR TITLE
Source ids in changeset

### DIFF
--- a/src/apis/data.js
+++ b/src/apis/data.js
@@ -151,5 +151,17 @@ module.exports = function(config) {
       }
 
     }
+  }, {
+    'name': 'GET source/:id(\\d+)',
+    'description': 'Gets source id for all elements in a changeset.',
+    'format': 'url',
+    'method': 'GET',
+    'path': 'source/:id(\\d+)',
+    'process': function (req, res) {
+      // Lookup the node in the database
+      var query = "select id, pgs_current_nodes.user from  pgs_current_nodes where changeset = '{{id}}'";
+      console.log(query);
+      database(req, res).query(query, 'source', apiFunctions.respond);
+    }
   }];
 };

--- a/src/apis/data.js
+++ b/src/apis/data.js
@@ -158,8 +158,15 @@ module.exports = function(config) {
     'method': 'GET',
     'path': 'source/:id(\\d+)',
     'process': function (req, res) {
-      // Lookup the node in the database
-      var query = "select id, pgs_current_nodes.user from  pgs_current_nodes where changeset = '{{id}}'";
+      var query = "" +
+          "SELECT w.changeset_id, u.name as \"user\", 'create' as action, 'node' as element, w.id as places_id, w.tags->'nps:source_system_key_value' as gis_id, w.version, w.tstamp " +
+          "FROM nodes as w join users as u on u.id = w.user_id where w.tags ? 'nps:source_system_key_value' and w.changeset_id = '{{id}}' " +
+          "UNION " +
+          "SELECT w.changeset_id, u.name as \"user\", 'create' as action, 'way' as element, w.id as places_id, w.tags->'nps:source_system_key_value' as gis_id, w.version, w.tstamp " +
+          "FROM ways as w join users as u on u.id = w.user_id where w.tags ? 'nps:source_system_key_value' and w.changeset_id = '{{id}}' " +
+          "UNION " +
+          "SELECT w.changeset_id, u.name as \"user\", 'create' as action, 'relation' as element, w.id as places_id, w.tags->'nps:source_system_key_value' as gis_id, w.version, w.tstamp " +
+          "FROM relations as w join users as u on u.id = w.user_id where w.tags ? 'nps:source_system_key_value' and w.changeset_id = '{{id}}'";
       console.log(query);
       database(req, res).query(query, 'source', apiFunctions.respond);
     }


### PR DESCRIPTION
Jim,
This gives me what I need from a changeset to track changes.  This api call is useful if I don’t get a diffresult back because of a time out error.

I’m flexible on the name and other aspects if you have some ideas.

I am hoping to do something with the timestamp, I would prefer a simple ISO format.   You can see what I mean at http://165.83.60.142:8000/api/data/source/34237692.
