### PR TITLE
Changeset status

### DIFF
--- a/scripts/sql_scripts/api/func_upsert_changeset.sql
+++ b/scripts/sql_scripts/api/func_upsert_changeset.sql
@@ -8,13 +8,9 @@ CREATE OR REPLACE FUNCTION upsert_changeset(
     v_id ALIAS FOR $1;
     v_user ALIAS FOR $2;
     v_tags ALIAS FOR $3;
-    v_timestamp timestamp without time zone;
     v_new_id bigint;
     v_return_json json;
     BEGIN
-      -- Set some values
-        v_timestamp := now();
-
       -- Determine if there needs to be a new changeset
     SELECT
       COALESCE((
@@ -45,8 +41,8 @@ CREATE OR REPLACE FUNCTION upsert_changeset(
       ) VALUES (
         v_new_id,
         v_user,
-        now(),
-        now()
+        now(),  -- in Postgres, now() returns the start time of the current transaction
+        now()   -- closed_at == created_at implies changeset is actually open not closed;
       );
     END IF;
 

--- a/scripts/sql_scripts/api/view_2_current_views.sql
+++ b/scripts/sql_scripts/api/view_2_current_views.sql
@@ -194,7 +194,7 @@ SELECT
   changesets.user_id as uid,
   changesets.created_at AT TIME ZONE 'UTC' as created_at,
   changesets.closed_at AT TIME ZONE 'UTC' as closed_at,
-  (select (closed_at>created_at AND num_changes<=50000) AS open from changesets open where open.id = changesets.id) as open,
+  closed_at = created_at AS open,
   changesets.min_lat/10000000::float as min_lat,
   changesets.min_lon/10000000::float as min_lon,
   changesets.max_lat/10000000::float as max_lat,


### PR DESCRIPTION
The change to view_2_current_views.sql corrects the logic for determining the open status of a changeset (it is currently backwards).

The change to the upsert_change function is optional, it clarifies something that confused me and removes an unused variable.
