### PR TITLE
Async upload changeset

### DIFF
--- a/src/apis/0.6.js
+++ b/src/apis/0.6.js
@@ -564,15 +564,12 @@ module.exports = function (config) {
     'auth': apiFunctions.auth(config),
     'process': function (req, res) {
       //TODO: Error right away if the changeset isn't open(exists) or is not owned by the (authenticated) caller
-      console.log('Starting ASYNC Upload Changeset, params:', req.params);
       apiFunctions.readXmlReq(req, function (error, data) {
         if (!error && data) {
           res.send('', 'txt');
-          console.log('Sent response, start ASYNC processing of changeset');
           apiFunctions.readOsmChange.changeset(data, database, function (result) {
             var query = "SELECT close_changeset from close_changeset('{{id}}')";
             database(req, res).query(query, 'changeset');
-            console.log('Changeset ASYNC closed, params:', req.params, 'result: ', result);
           });
         } else {
           res.status({

--- a/src/apis/0.6.js
+++ b/src/apis/0.6.js
@@ -557,6 +557,32 @@ module.exports = function (config) {
       });
     }
   }, {
+    'name': 'PUT changeset/#id/upload_async',
+    'description': 'Returns after receiving the upload file, then updates __and closes__ the changeset.',
+    'method': 'POST',
+    'path': 'changeset/:id(\\d+)/upload_async',
+    'auth': apiFunctions.auth(config),
+    'process': function (req, res) {
+      //TODO: Error right away if the changeset isn't open(exists) or is not owned by the (authenticated) caller
+      console.log('Starting ASYNC Upload Changeset, params:', req.params);
+      apiFunctions.readXmlReq(req, function (error, data) {
+        if (!error && data) {
+          res.send('', 'txt');
+          console.log('Sent response, start ASYNC processing of changeset');
+          apiFunctions.readOsmChange.changeset(data, database, function (result) {
+            var query = "SELECT close_changeset from close_changeset('{{id}}')";
+            database(req, res).query(query, 'changeset');
+            console.log('Changeset ASYNC closed, params:', req.params, 'result: ', result);
+          });
+        } else {
+          res.status({
+            'statusCode': 400,
+            'details': error
+          });
+        }
+      });
+    }
+  }, {
     // http://wiki.openstreetmap.org/wiki/OsmChange
     'name': 'GET changeset/#id/download',
     'description': 'Downloads all the changed elements in a changeset in OsmChange format.',


### PR DESCRIPTION
Jim, this works well on my test server.  the data/source query will return a 404 while the changes is processing, and then good results when it is done, so I can poll for results to finish processing on the client end.

A draw back to large uploads (with the async call or the regular call) is that while queries against snapshot are responsive, it appears the api database (at least on my server) becomes unresponsive to new requests while the upsert changeset transaction is processing.

I don’t anticipate many large uploads (we have two, and I can schedule them for off hours), and I think other parks/regions plan to send you the osm upload file for large uploads, so this hopefully will not be a problem.

Nevertheless, I can program a time of day restriction on large uploads.
  
thoughts?